### PR TITLE
Handle empty display list as found in Resident Evil II

### DIFF
--- a/src/Glide64/rdp.cpp
+++ b/src/Glide64/rdp.cpp
@@ -761,6 +761,10 @@ EXPORT void CALL ProcessDList(void)
   FRDP("--- NEW DLIST --- crc: %08lx, ucode: %d, fbuf: %08lx, fbuf_width: %d, dlist start: %08lx, dlist_length: %d, x_scale: %f, y_scale: %f\n", uc_crc, settings.ucode, *gfx.VI_ORIGIN_REG, *gfx.VI_WIDTH_REG, dlist_start, dlist_length, (*gfx.VI_X_SCALE_REG & 0xFFF)/1024.0f, (*gfx.VI_Y_SCALE_REG & 0xFFF)/1024.0f);
   FRDP_E("--- NEW DLIST --- crc: %08lx, ucode: %d, fbuf: %08lx\n", uc_crc, settings.ucode, *gfx.VI_ORIGIN_REG);
 
+  // Do nothing if dlist is empty
+  if (dlist_start == 0)
+      return;
+
   if (cpu_fb_write == TRUE)
     DrawPartFrameBufferToScreen();
   if ((settings.hacks&hack_Tonic) && dlist_length < 16)
@@ -3396,6 +3400,10 @@ void DetectFrameBufferUsage ()
 
   wxUint32 dlist_start = *(wxUint32*)(gfx.DMEM+0xFF0);
   wxUint32 a;
+
+  // Do nothing if dlist is empty
+  if (dlist_start == 0)
+      return;
 
   int tidal = FALSE;
   if ((settings.hacks&hack_PMario) && (rdp.copy_ci_index || rdp.frame_buffers[rdp.copy_ci_index].status == ci_copy_self))


### PR DESCRIPTION
The case when display list pointer is null wasn't handled previously
and could cause infinite loops. This patch addresses this case.
Now Resident Evil II boots even with the HLE rsp plugin.
