### PR TITLE
Detect OpenBSD's PowerPC platforms, macppc and socppc.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -92,7 +92,7 @@ ifneq ("$(filter pentium i%86,$(HOST_CPU))","")
   ARCH_DETECTED := 32BITS
   PIC ?= 0
 endif
-ifneq ("$(filter ppc powerpc,$(HOST_CPU))","")
+ifneq ("$(filter ppc macppc socppc powerpc,$(HOST_CPU))","")
   CPU := PPC
   ARCH_DETECTED := 32BITS
   BIG_ENDIAN := 1


### PR DESCRIPTION
This change was made to the other plugins’ makefiles a long time ago but got missed here.
