### PR TITLE
Adreno

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -313,6 +313,9 @@ endif
 ifeq ($(NO_ASM), 1)
   CFLAGS += -DNO_ASM
 endif
+ifeq ($(ADRENO_ROTATION_HACK), 1)
+  CFLAGS += -DADRENO_ROTATION_HACK
+endif
 
 # set installation options
 ifeq ($(PREFIX),)
@@ -431,6 +434,7 @@ targets:
 	@echo "    POSTFIX=name  == String added to the name of the the build (default: '')"
 	@echo "    HIRES=(1|0)   == Enables/Disables support for hires textures and texture filters (default: 1)"
 	@echo "    TXCDXTN=(1|0) == Enable/Disable external txc_dxtn library (default: 0)"
+	@echo "    ADRENO_ROTATION_HACK=1 == enable adreno rotation hack (rotate screen contents 90°)"
 	@echo "  Install Options:"
 	@echo "    PREFIX=path   == install/uninstall prefix (default: /usr/local)"
 	@echo "    SHAREDIR=path == path to install shared data files (default: PREFIX/share/mupen64plus)"

--- a/src/Glide64/Main.cpp
+++ b/src/Glide64/Main.cpp
@@ -482,7 +482,11 @@ void ReadSettings ()
   settings.special_fog = Config_ReadInt("fog", "Fog: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_buff_clear = Config_ReadInt("buff_clear", "Buffer clear on every frame: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_swapmode = Config_ReadInt("swapmode", "Buffer swapping method: -1=Game default, 0=swap buffers when vertical interrupt has occurred, 1=swap buffers when set of conditions is satisfied. Prevents flicker on some games, 2=mix of first two methods", -1, TRUE, FALSE);
+#ifdef ADRENO_ROTATION_HACK
+  settings.special_aspect = Config_ReadInt("aspect", "Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original", 2, TRUE, FALSE);
+#else
   settings.special_aspect = Config_ReadInt("aspect", "Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original", -1, TRUE, FALSE);
+#endif
   settings.special_lodmode = Config_ReadInt("lodmode", "LOD calculation: -1=Game default, 0=disable. 1=fast, 2=precise", -1, TRUE, FALSE);
   settings.special_fb_smart = Config_ReadInt("fb_smart", "Smart framebuffer: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_fb_hires = Config_ReadInt("fb_hires", "Hardware frame buffer emulation: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);

--- a/src/Glitch64/OGLEScombiner.cpp
+++ b/src/Glitch64/OGLEScombiner.cpp
@@ -176,6 +176,13 @@ SHADER_HEADER
 "uniform vec3 vertexOffset;                                     \n" //Moved some calculations from grDrawXXX to shader
 "uniform vec4 textureSizes;                                     \n" 
 "uniform vec3 fogModeEndScale;                                  \n" //0 = Mode, 1 = gl_Fog.end, 2 = gl_Fog.scale
+#ifdef ADRENO_ROTATION_HACK
+"mat4 rotation_matrix = mat4(                                   \n"
+"       0.0, -1.0,  0.0,  0.0,                                  \n"
+"       1.0,  0.0,  0.0,  0.0,                                  \n"
+"       0.0,  0.0,  1.0,  0.0,                                  \n"
+"       0.0,  0.0,  0.0,  1.0);                                 \n"
+#endif
 SHADER_VARYING
 "                                                               \n"
 "void main()                                                    \n"
@@ -187,6 +194,9 @@ SHADER_VARYING
 "  gl_Position.z = aVertex.z / Z_MAX;                                       \n"
 "  gl_Position.w = 1.0;                                                     \n"
 "  gl_Position /= q;                                                        \n"
+#ifdef ADRENO_ROTATION_HACK
+"  gl_Position = rotation_matrix * gl_Position;                             \n"
+#endif
 "  gl_FrontColor = aColor.bgra;                                             \n"
 "                                                                           \n"
 "  gl_TexCoord[0] = vec4(aMultiTexCoord0.xy / q / textureSizes.xy,0,1);     \n"


### PR DESCRIPTION
Implement a rotation hack, for adreno devices where landscape mode is broken due to a GPU driver bug. This renders the game in portrait mode and rotates the screen contents by 90 degrees, so it can be viewed in landscape mode.
