### PR TITLE
adreno (TM) 3xx

### DIFF
--- a/src/Glitch64/OGLESgeometry.cpp
+++ b/src/Glitch64/OGLESgeometry.cpp
@@ -31,11 +31,9 @@
 #define Z_MAX (65536.0f)
 #define VERTEX_SIZE sizeof(VERTEX) //Size of vertex struct
 
-#ifdef ANDROID_EDITION
-#include "ae_imports.h"
-static float polygonOffsetFactor;
-static float polygonOffsetUnits;
-#endif
+int force_polygon_offset = 0;
+float polygonOffsetFactor;
+float polygonOffsetUnits;
 
 static int xy_off;
 static int xy_en;
@@ -384,14 +382,17 @@ grDepthBiasLevel( FxI32 level )
   LOG("grDepthBiasLevel(%d)\r\n", level);
   if (level)
   {
-    #ifdef ANDROID_EDITION
-    glPolygonOffset(polygonOffsetFactor, polygonOffsetUnits);
-    #else
-    if(w_buffer_mode)
-      glPolygonOffset(1.0f, -(float)level*zscale/255.0f);
+    if(force_polygon_offset)
+    {
+        glPolygonOffset(polygonOffsetFactor, polygonOffsetUnits);
+    }
     else
-      glPolygonOffset(0, (float)level*biasFactor);
-    #endif
+    {
+        if(w_buffer_mode)
+          glPolygonOffset(1.0f, -(float)level*zscale/255.0f);
+        else
+          glPolygonOffset(0, (float)level*biasFactor);
+    }
     glEnable(GL_POLYGON_OFFSET_FILL);
   }
   else

--- a/src/Glitch64/OGLESglitchmain.cpp
+++ b/src/Glitch64/OGLESglitchmain.cpp
@@ -48,6 +48,10 @@
 #include <IL/il.h>
 #endif
 
+extern int force_polygon_offset;
+extern float polygonOffsetFactor;
+extern float polygonOffsetUnits;
+
 extern void (*renderCallback)(int);
 
 wrapper_config config = {0, 0, 0, 0};
@@ -712,6 +716,14 @@ grSstWinOpen(
 
   //void FindBestDepthBias();
   //FindBestDepthBias();
+  // custom polygon offset for Adreno (TM) 3XX GPUs
+  if(NULL != strstr((const char*)glGetString(GL_VENDOR), "Qualcomm") && NULL != strstr((const char*)glGetString(GL_RENDERER), "Adreno (TM) 3"))
+  {
+    WriteLog(M64MSG_INFO, "Qualcomm Adreno (TM) 3XX detected, forcing polygon offset to factor=-0.2f, units=-0.2f");
+    force_polygon_offset = 1;
+    polygonOffsetFactor = -0.2f;
+    polygonOffsetUnits = -0.2f;
+  }
 
   init_geometry();
   init_textures();


### PR DESCRIPTION
enable code from mupen64plus-ae for determining a suitable glPolygonOffset for Adreno (TM) 3xx hardware
