### PR TITLE
Remove build flag for Jolla phone defaults.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -317,10 +317,6 @@ ifeq ($(NO_SSE), 1)
   CFLAGS += -DNOSSE
 endif
 
-ifneq ($(CFG_DEFAULTS),)
-  CFLAGS += -DCFG_DEFAULTS=$(CFG_DEFAULTS)
-endif
-
 # set installation options
 ifeq ($(PREFIX),)
   PREFIX := /usr/local
@@ -439,7 +435,6 @@ targets:
 	@echo "    POSTFIX=name  == String added to the name of the the build (default: '')"
 	@echo "    HIRES=(1|0)   == Enables/Disables support for hires textures and texture filters (default: 1)"
 	@echo "    TXCDXTN=(1|0) == Enable/Disable external txc_dxtn library (default: 0)"
-	@echo "    CFG_DEFAULTS=jp1 == Use config values optimized for the jolla phone 1"
 	@echo "  Install Options:"
 	@echo "    PREFIX=path   == install/uninstall prefix (default: /usr/local)"
 	@echo "    SHAREDIR=path == path to install shared data files (default: PREFIX/share/mupen64plus)"

--- a/src/Glide64/Config.cpp
+++ b/src/Glide64/Config.cpp
@@ -36,20 +36,10 @@ BOOL Config_Open()
     }
     ConfigSetDefaultBool(video_general_section, "Fullscreen", false, "Use fullscreen mode if True, or windowed mode if False");
     ConfigSetDefaultBool(video_general_section, "VerticalSync", true, "If true, prevent frame tearing by waiting for vsync before swapping");
-#if CFG_DEFAULTS == jp1
-    ConfigSetDefaultInt(video_general_section, "ScreenWidth", 540, "Width of output window or fullscreen width");
-    ConfigSetDefaultInt(video_general_section, "ScreenHeight", 960, "Height of output window or fullscreen height");
-#else
     ConfigSetDefaultInt(video_general_section, "ScreenWidth", 640, "Width of output window or fullscreen width");
     ConfigSetDefaultInt(video_general_section, "ScreenHeight", 480, "Height of output window or fullscreen height");
-#endif
     ConfigSetDefaultInt(video_glide64_section, "wrpAntiAliasing", 0, "Enable full-scene anti-aliasing by setting this to a value greater than 1");
-
-#if CFG_DEFAULTS == jp1
-    ConfigSetDefaultInt(video_general_section, "Rotate", 3, "Rotate screen contents: 0=0 degree, 1=90 degree, 2 = 180 degree, 3=270 degree");
-#else
     ConfigSetDefaultInt(video_general_section, "Rotate", 0, "Rotate screen contents: 0=0 degree, 1=90 degree, 2 = 180 degree, 3=270 degree");
-#endif
 
     return TRUE;
 }

--- a/src/Glide64/Main.cpp
+++ b/src/Glide64/Main.cpp
@@ -484,11 +484,7 @@ void ReadSettings ()
   settings.special_fog = Config_ReadInt("fog", "Fog: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_buff_clear = Config_ReadInt("buff_clear", "Buffer clear on every frame: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_swapmode = Config_ReadInt("swapmode", "Buffer swapping method: -1=Game default, 0=swap buffers when vertical interrupt has occurred, 1=swap buffers when set of conditions is satisfied. Prevents flicker on some games, 2=mix of first two methods", -1, TRUE, FALSE);
-#if CFG_DEFAULTS == jp1
-  settings.special_aspect = Config_ReadInt("aspect", "Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original", 2, TRUE, FALSE);
-#else
   settings.special_aspect = Config_ReadInt("aspect", "Aspect ratio: -1=Game default, 0=Force 4:3, 1=Force 16:9, 2=Stretch, 3=Original", -1, TRUE, FALSE);
-#endif
   settings.special_lodmode = Config_ReadInt("lodmode", "LOD calculation: -1=Game default, 0=disable. 1=fast, 2=precise", -1, TRUE, FALSE);
   settings.special_fb_smart = Config_ReadInt("fb_smart", "Smart framebuffer: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);
   settings.special_fb_hires = Config_ReadInt("fb_hires", "Hardware frame buffer emulation: -1=Game default, 0=disable. 1=enable", -1, TRUE, FALSE);


### PR DESCRIPTION
@krnlyng 

This should be handled by the front-end.  They're just default values, and by design are easy to override by editing the config file.

Also, the code guards are malformed, since jp1 is not a variable.  This was evaluating to true even when CFG_DEFAULTS wasn't defined in our makefile.
`#if CFG_DEFAULTS == jp1`
