### PR TITLE
Implement optional frameskip feature.

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -312,6 +312,9 @@ endif
 ifeq ($(NO_SSE), 1)
   CFLAGS += -DNOSSE
 endif
+ifeq ($(USE_FRAMESKIPPER), 1)
+  CFLAGS += -DUSE_FRAMESKIPPER
+endif
 
 # set installation options
 ifeq ($(PREFIX),)
@@ -359,6 +362,11 @@ else
 		$(SRCDIR)/Glitch64/OGLgeometry.cpp \
 		$(SRCDIR)/Glitch64/OGLglitchmain.cpp \
 		$(SRCDIR)/Glitch64/OGLtextures.cpp
+endif
+
+ifeq ($(USE_FRAMESKIPPER), 1)
+	SOURCE += \
+		$(SRCDIR)/Glide64/FrameSkipper.cpp
 endif
 
 ifneq ($(HIRES), 0)
@@ -424,6 +432,7 @@ targets:
 	@echo "    NO_ASM=1      == build without inline assembly code (x86 MMX/SSE)"
 	@echo "    USE_GLES=1    == build against GLESv2 instead of OpenGL"
 	@echo "    NO_SSE=1      == build without SSE support"
+	@echo "    USE_FRAMESKIPPER=1 == build with frameskipper feature"
 	@echo "    APIDIR=path   == path to find Mupen64Plus Core headers"
 	@echo "    OPTFLAGS=flag == compiler optimization (default: -O3 -flto)"
 	@echo "    WARNFLAGS=flag == compiler warning levels (default: -Wall)"

--- a/src/Glide64/FrameSkipper.cpp
+++ b/src/Glide64/FrameSkipper.cpp
@@ -1,0 +1,76 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Copyright (C) 2011 yongzh (freeman.yong@gmail.com)                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "FrameSkipper.h"
+#include <SDL_timer.h>
+
+FrameSkipper::FrameSkipper()
+  : _skipType(AUTO), _maxSkips(2), _targetFPS(60),
+    _skipCounter(0), _initialTicks(0), _actualFrame(0)
+{
+}
+
+void FrameSkipper::update()
+{
+  if (_maxSkips < 1)
+  {
+    // Frameskip disabled, do nothing
+  }
+  else if (_skipType == MANUAL)
+  {
+    // Skip this frame based on a deterministic skip rate
+    if (++_skipCounter > _maxSkips)
+      _skipCounter = 0;
+  }
+  else if (_initialTicks > 0) // skipType == AUTO, running
+  {
+    // Compute the frame number we want be at, based on elapsed time and target FPS
+    unsigned int elapsedMilliseconds = SDL_GetTicks() - _initialTicks;
+    unsigned int desiredFrame = (elapsedMilliseconds * _targetFPS) / 1000;
+
+    // Record the frame number we are actually at
+    _actualFrame++;
+
+    // See if we need to skip
+    if (desiredFrame < _actualFrame)
+    {
+      // We are ahead of schedule, so do nothing
+    }
+    else if (desiredFrame > _actualFrame && _skipCounter < _maxSkips)
+    {
+      // We are behind schedule and we are allowed to skip this frame, so skip this frame
+      _skipCounter++;
+    }
+    else
+    {
+      // We are on schedule, or we are not allowed to skip this frame...
+      // ... so do not skip this frame
+      _skipCounter = 0;
+      // ... and pretend we are on schedule (if not already)
+      _actualFrame = desiredFrame;
+    }
+  }
+  else // skipType == AUTO, initializing
+  {
+    // First frame, initialize auto-skip variables
+    _initialTicks = SDL_GetTicks();
+    _actualFrame = 0;
+    _skipCounter = 0;
+  }
+}

--- a/src/Glide64/FrameSkipper.h
+++ b/src/Glide64/FrameSkipper.h
@@ -1,0 +1,48 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Copyright (C) 2011 yongzh (freeman.yong@gmail.com)                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#ifndef FRAME_SKIPPER_H
+#define FRAME_SKIPPER_H
+
+class FrameSkipper
+{
+public:
+  enum { AUTO, MANUAL };
+
+  FrameSkipper();
+
+  void setSkips(int type, int max) { _skipType = type; _maxSkips = max; }
+
+  void setTargetFPS(int fps) { _targetFPS = fps; }
+
+  bool willSkipNext() { return (_skipCounter > 0); }
+
+  void update();
+
+private:
+  int _skipType;
+  int _maxSkips;
+  int _targetFPS;
+  int _skipCounter;
+  unsigned int _initialTicks;
+  unsigned int _actualFrame;
+};
+
+#endif
+

--- a/src/Glide64/rdp.cpp
+++ b/src/Glide64/rdp.cpp
@@ -51,6 +51,11 @@
 #include "FBtoScreen.h"
 #include "CRC.h"
 
+#ifdef USE_FRAMESKIPPER
+#include "FrameSkipper.h"
+extern FrameSkipper frameSkipper;
+#endif
+
 /*
 const int NumOfFormats = 3;
 SCREEN_SHOT_FORMAT ScreenShotFormats[NumOfFormats] = { {wxT("BMP"), wxT("bmp"), wxBITMAP_TYPE_BMP}, {wxT("PNG"), wxT("png"), wxBITMAP_TYPE_PNG}, {wxT("JPEG"), wxT("jpeg"), wxBITMAP_TYPE_JPEG} };
@@ -577,7 +582,11 @@ extern "C" {
 EXPORT void CALL ProcessDList(void)
 {
   SoftLocker lock(mutexProcessDList);
+#ifdef USE_FRAMESKIPPER
+  if (frameSkipper.willSkipNext() || !lock.IsOk()) //mutex is busy
+#else
   if (!lock.IsOk()) //mutex is busy
+#endif
   {
     if (!fullscreen)
       drawNoFullscreenMessage();

--- a/src/Glide64/rdp.h
+++ b/src/Glide64/rdp.h
@@ -220,6 +220,11 @@ typedef struct {
   float polygon_offset_factor;
   float polygon_offset_units;
 
+#ifdef USE_FRAMESKIPPER
+  int autoframeskip;
+  int maxframeskip;
+#endif
+
   int filtering;
   int fog;
   int buff_clear;


### PR DESCRIPTION
On mobile hardware, this makes a big difference in playability on most ROMs.  E.g. on the Tegra3-based Nexus 7 (2012) and OUYA, games like DK64 and Diddy Kong Racing are not playable without this feature.

I understand that frameskip is blasphemy in some communities, so this feature is only enabled via build flag.  In other words, by default, this PR makes no change whatsoever to the compiled binary.

@paulscode