### PR TITLE
include SDL_opengles2.h instead of SDL_opengles.h

### DIFF
--- a/src/Glitch64/OGLESglitchmain.cpp
+++ b/src/Glitch64/OGLESglitchmain.cpp
@@ -39,7 +39,7 @@
 #include "main.h"
 #include "m64p.h"
 
-#include <SDL_opengles.h>
+#include <SDL_opengles2.h>
 //#include <GL/glext.h>
 
 #define OPENGL_CHECK_ERRORS { const GLenum errcode = glGetError(); if (errcode != GL_NO_ERROR) LOG("OpenGL Error code %i in '%s' line %i\n", errcode, __FILE__, __LINE__-1); }


### PR DESCRIPTION
(when using USE_GLES=1) we link against GLESv2, not GLESv1, spotted this while trying to build an rpm package for my platform
