### PR TITLE
Fix broken C version of MulMatricesC

### DIFF
--- a/src/Glide64/3dmath.cpp
+++ b/src/Glide64/3dmath.cpp
@@ -190,16 +190,37 @@ void InverseTransformVectorC (float *src, float *dst, float mat[4][4])
 
 void MulMatricesC(float m1[4][4],float m2[4][4],float r[4][4])
 {
-  for (int i=0; i<4; i++)
-  {
-    for (int j=0; j<4; j++)
+    float row[4][4];
+    register unsigned int i, j;
+
+    for (i = 0; i < 4; i++)
+        for (j = 0; j < 4; j++)
+            row[i][j] = m2[i][j];
+    for (i = 0; i < 4; i++)
     {
-      r[i][j] = m1[i][0] * m2[0][j] +
-                m1[i][1] * m2[1][j] +
-                m1[i][2] * m2[2][j] +
-                m1[i][3] * m2[3][j];
+        float leftrow[4], destrow[4];
+        float summand[4][4];
+
+        for (j = 0; j < 4; j++)
+            leftrow[j] = m1[i][j];
+
+        for (j = 0; j < 4; j++)
+            summand[0][j] = leftrow[0] * row[0][j];
+        for (j = 0; j < 4; j++)
+            summand[1][j] = leftrow[1] * row[1][j];
+        for (j = 0; j < 4; j++)
+            summand[2][j] = leftrow[2] * row[2][j];
+        for (j = 0; j < 4; j++)
+            summand[3][j] = leftrow[3] * row[3][j];
+
+        for (j = 0; j < 4; j++)
+            r[i][j] =
+                summand[0][j]
+              + summand[1][j]
+              + summand[2][j]
+              + summand[3][j]
+        ;
     }
-  }
 }
 
 // 2008.03.29 H.Morii - added SSE 3DNOW! 3x3 1x3 matrix multiplication


### PR DESCRIPTION
Me and cxd4 (Hatcat/mephostophilis) stumbled upon this while backporting some stuff to the libretro version.

The C version of MulMatricesC appears to be totally broken. I guess this went unnoticed before because it would default to the SSE2 codepath version on regular desktops.

Read the explanation by cxd4 here:

https://github.com/libretro/mupen64plus-libretro/pull/159

' repairs were made to the ANSI C code which had broken texture elements in the backgrounds of games like Super Mario 64. In addition, the new ANSI C function is written in vectorized loop style, such that GCC can very easily create the SSE instructions relevant to said loops in a manner perhaps more optimized than the original SSE-fixed code.'
