### PR TITLE
Revert to original Glitch64 LOG macro definition.

### DIFF
--- a/src/Glitch64/OGLESglitchmain.cpp
+++ b/src/Glitch64/OGLESglitchmain.cpp
@@ -306,7 +306,7 @@ LogManager logManager;
 #else // LOGGING
 #define OPEN_LOG()
 #define CLOSE_LOG()
-//#define LOG
+#define LOG
 #endif // LOGGING
 
 FX_ENTRY void FX_CALL

--- a/src/Glitch64/OGLESglitchmain.cpp
+++ b/src/Glitch64/OGLESglitchmain.cpp
@@ -254,7 +254,7 @@ void display_error()
 #endif // _WIN32
 
 #ifdef LOGGING
-char out_buf[256];
+char log_buf[256];
 bool log_open = false;
 std::ofstream log_file;
 
@@ -285,8 +285,8 @@ void LOG(const char *text, ...)
     return;
 	va_list ap;
 	va_start(ap, text);
-	vsprintf(out_buf, text, ap);
-  log_file << out_buf;
+	vsprintf(log_buf, text, ap);
+  log_file << log_buf;
   log_file.flush();
 	va_end(ap);
 }

--- a/src/Glitch64/OGLglitchmain.cpp
+++ b/src/Glitch64/OGLglitchmain.cpp
@@ -250,7 +250,7 @@ void display_error()
 #endif // _WIN32
 
 #ifdef LOGGING
-char out_buf[256];
+char log_buf[256];
 bool log_open = false;
 std::ofstream log_file;
 
@@ -281,8 +281,8 @@ void LOG(const char *text, ...)
     return;
 	va_list ap;
 	va_start(ap, text);
-	vsprintf(out_buf, text, ap);
-  log_file << out_buf;
+	vsprintf(log_buf, text, ap);
+  log_file << log_buf;
   log_file.flush();
 	va_end(ap);
 }

--- a/src/Glitch64/OGLglitchmain.cpp
+++ b/src/Glitch64/OGLglitchmain.cpp
@@ -302,7 +302,7 @@ LogManager logManager;
 #else // LOGGING
 #define OPEN_LOG()
 #define CLOSE_LOG()
-//#define LOG
+#define LOG
 #endif // LOGGING
 
 FX_ENTRY void FX_CALL

--- a/src/Glitch64/glitchmain.h
+++ b/src/Glitch64/glitchmain.h
@@ -23,7 +23,6 @@
 
 #include <m64p_types.h>
 
-#define LOG(...) WriteLog(M64MSG_VERBOSE, __VA_ARGS__)
 #define LOGINFO(...) WriteLog(M64MSG_INFO, __VA_ARGS__)
 #ifdef __cplusplus
 extern "C" {
@@ -385,11 +384,11 @@ grConstantColorValueExt(GrChipID_t    tmu,
 #ifdef LOGGING
 void OPEN_LOG();
 void CLOSE_LOG();
-//void LOG(const char *text, ...);
+void LOG(const char *text, ...);
 #else // LOGGING
 #define OPEN_LOG()
 #define CLOSE_LOG()
-//#define LOG
+#define LOG
 #endif // LOGGING
 
 #endif


### PR DESCRIPTION
Reverts change made in commit b037632.
https://github.com/mupen64plus/mupen64plus-video-glide64mk2/commit/b0376322c9be55b3348c28eb13c8d2b375161ddb#diff-ae724f0d8acdb55b9336c5905ba15311R280

The original Glitch64 LOG macro was used only for development/debugging
purposes and was never intended to be used in any sort of end-user
context.  It is invoked in every gr* method, which produces dozens of
log entries per frame.

The commit referenced above changed the LOG macro to use m64p verbose
logging, which is presentable to the user.  There are two problems with
that:

1. With verbose logging enabled, the Glitch64 messages completely swamp
   the verbose messages from all other modules as well as Glide64 and
   GlideHQ.  Not only does this make it difficult to parse information
   from the logs, but it also brings framerate to an unusable 1-3 FPS on
   a modern PC.

2. Even with verbose logging disabled, the overhead alone of assembling
   log messages (even if never displayed) is enough to significantly
   reduce frame rate.  This is especially noticeable on mobile hardware.
   For example, on a Tegra3-based 2012 Nexus 7, framerate during the
   DK64 intro rap scene is very noticeably slower with LOG enabled:
     - with LOG enabled: 7-20 FPS
     - with LOG disabled: 15-30 FPS
   In many places, FPS doubles after disabling the LOG macro.