### PR TITLE
Linker Optimization speedup

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -122,7 +122,7 @@ ifeq ("$(CPU)","NONE")
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS
-OPTFLAGS ?= -O2 -flto=jobserver
+OPTFLAGS ?= -O3 -flto=jobserver
 WARNFLAGS ?= -Wall
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/Glitch64/inc -DGCC
 CXXFLAGS += -fvisibility-inlines-hidden -std=gnu++0x

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -122,7 +122,7 @@ ifeq ("$(CPU)","NONE")
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS
-OPTFLAGS ?= -O2 -flto
+OPTFLAGS ?= -O2 -flto=jobserver
 WARNFLAGS ?= -Wall
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -I../../src/Glitch64/inc -DGCC
 CXXFLAGS += -fvisibility-inlines-hidden -std=gnu++0x
@@ -481,6 +481,6 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp
 	$(COMPILE.cc) -o $@ $<
 
 $(TARGET): $(OBJECTS)
-	$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
+	+$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
 
 .PHONY: all clean install uninstall targets


### PR DESCRIPTION
The linking step speed was increased during

   make -C projects/unix/ all -j4

The whole build took 52 seconds before using the jobserver and took 31 seconds after enabling it. The linking step went from 44 seconds without jobserver to 23s after enabling it.