### PR TITLE
Don't include date in plugininfo to make build reproducible

### DIFF
--- a/src/Glide64/Main.cpp
+++ b/src/Glide64/Main.cpp
@@ -69,7 +69,6 @@ int  ghq_dmptex_toggle_key = 0;
 #endif
 
 #define G64_VERSION "G64 Mk2"
-#define RELTIME "Date: " __DATE__// " Time: " __TIME__
 
 #ifdef EXT_LOGGING
 std::ofstream extlog;
@@ -1723,7 +1722,7 @@ void CALL GetDllInfo ( PLUGIN_INFO * PluginInfo )
   VLOG ("GetDllInfo ()\n");
   PluginInfo->Version = 0x0103;     // Set to 0x0103
   PluginInfo->Type  = PLUGIN_TYPE_GFX;  // Set to PLUGIN_TYPE_GFX
-  sprintf (PluginInfo->Name, "Glide64mk2 " G64_VERSION RELTIME);  // Name of the DLL
+  sprintf (PluginInfo->Name, "Glide64mk2 " G64_VERSION);  // Name of the DLL
 
   // If DLL supports memory these memory options then set them to TRUE or FALSE
   //  if it does not support it


### PR DESCRIPTION
See https://fosdem.org/2015/interviews/2015-holger-levsen/ to give a brief idea about reproducible builds. You still need need the patches from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65015 when you want to use LTO together with reproducible builds on systems using ELF binaries.

The patch was taken from Debian