### PR TITLE
Fixed FrameSkipper not drawing first frame (in MANUAL mode)

### DIFF
--- a/src/Glide64/FrameSkipper.cpp
+++ b/src/Glide64/FrameSkipper.cpp
@@ -66,7 +66,7 @@ void FrameSkipper::update()
       _actualFrame = desiredFrame;
     }
   }
-  else // skipType == AUTO, initializing
+  if (_initialTicks == 0) // skipType == AUTO, initializing
   {
     // First frame, initialize auto-skip variables
     _initialTicks = SDL_GetTicks();

--- a/src/Glide64/FrameSkipper.cpp
+++ b/src/Glide64/FrameSkipper.cpp
@@ -66,7 +66,7 @@ void FrameSkipper::update()
       _actualFrame = desiredFrame;
     }
   }
-  if (_initialTicks == 0) // skipType == AUTO, initializing
+  if (_initialTicks == 0) // initializing
   {
     // First frame, initialize auto-skip variables
     _initialTicks = SDL_GetTicks();


### PR DESCRIPTION
When FrameSkipper is in manual mode, it does not draw the first frame. This causes flickering glitch patterns for the first few frames (for whatever the skip count is set to).