### PR TITLE
Update homepage links

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -1,6 +1,6 @@
 #/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 # *   Mupen64plus-video-glide64mk2 - Makefile                               *
-# *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+# *   Mupen64Plus homepage: https://mupen64plus.org/                        *
 # *   Copyright (C) 2010 Jon Ring                                           *
 # *   Copyright (C) 2007-2009 Richard Goedeken                              *
 # *   Copyright (C) 2007-2008 DarkJeztr Tillin9                             *

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -70,7 +70,7 @@ ifeq ("$(patsubst MINGW%,MINGW,$(UNAME))","MINGW")
   CPPFLAGS += -DNO_FILTER_THREAD
 endif
 ifeq ("$(OS)","NONE")
-  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error OS type "$(UNAME)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # detect system architecture
@@ -119,7 +119,7 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
   endif
 endif
 ifeq ("$(CPU)","NONE")
-  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
+  $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif
 
 # base CFLAGS, LDLIBS, and LDFLAGS

--- a/src/Glide64/m64p.h
+++ b/src/Glide64/m64p.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Glide64 - Glide video plugin for Nintendo 64 emulators.
- * http://bitbucket.org/richard42/mupen64plus-video-glide64mk2/
+ * https://github.com/mupen64plus/mupen64plus-video-glide64mk2/
  *
  * Copyright (C) 2010 Jon Ring
  *

--- a/src/Glide64/osal_dynamiclib.h
+++ b/src/Glide64/osal_dynamiclib.h
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-video-glide64mk2 - osal_dynamiclib.h                      *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/Glide64/osal_dynamiclib_unix.c
+++ b/src/Glide64/osal_dynamiclib_unix.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-video-glide64mk2 - osal_dynamiclib_unix.c                 *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/Glide64/osal_dynamiclib_win32.c
+++ b/src/Glide64/osal_dynamiclib_win32.c
@@ -1,6 +1,6 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-video-glide64mk2 - osal_dynamiclib_win32.c                *
- *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/src/Glitch64/m64p.h
+++ b/src/Glitch64/m64p.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * Glide64 - Glide video plugin for Nintendo 64 emulators.
- * http://bitbucket.org/wahrhaft/mupen64plus-video-glide64/
+ * https://github.com/mupen64plus/mupen64plus-video-glide64mk2/
  *
  * Copyright (C) 2010 Jon Ring
  *


### PR DESCRIPTION
Linking to the Google Code page isn’t much use anymore.

Across all repos, I changed issue tracker links to the Github tracker, wiki links to the mupen64plus.org wiki, and homepage links to mupen64plus.org.

For the most part I didn’t link to individual repos, for maintenance reasons (if we ever move away from Github, or if we copy files across repos, or…).