### PR TITLE
Remove 'register' storage class specifier.

### DIFF
--- a/src/Glide64/3dmath.cpp
+++ b/src/Glide64/3dmath.cpp
@@ -50,7 +50,7 @@ extern "C" {
 void calc_light (VERTEX *v)
 {
   float light_intensity = 0.0f;
-  register float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
+  float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
   for (wxUint32 l=0; l<rdp.num_lights; l++)
   {
     light_intensity = DotProduct (rdp.light_vector[l], v->vec);
@@ -155,16 +155,16 @@ void calc_sphere (VERTEX *v)
 #endif
 }
 
-float DotProductC(register float *v1, register float *v2)
+float DotProductC(float *v1, float *v2)
 {
-    register float result;
+    float result;
     result = v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
     return(result);
 }
 
 void NormalizeVectorC(float *v)
 {
-    register float len;
+    float len;
     len = sqrtf(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
     if (len > 0.0f)
     {
@@ -191,7 +191,7 @@ void InverseTransformVectorC (float *src, float *dst, float mat[4][4])
 void MulMatricesC(float m1[4][4],float m2[4][4],float r[4][4])
 {
     float row[4][4];
-    register unsigned int i, j;
+    unsigned int i, j;
 
     for (i = 0; i < 4; i++)
         for (j = 0; j < 4; j++)

--- a/src/Glide64/3dmath.h
+++ b/src/Glide64/3dmath.h
@@ -48,7 +48,7 @@ extern MULMATRIX MulMatrices;
 typedef void (*TRANSFORMVECTOR)(float *src,float *dst,float mat[4][4]); 
 extern TRANSFORMVECTOR TransformVector;
 extern TRANSFORMVECTOR InverseTransformVector;
-typedef float (*DOTPRODUCT)(register float *v1, register float *v2);
+typedef float (*DOTPRODUCT)(float *v1, float *v2);
 extern DOTPRODUCT DotProduct;
 typedef void (*NORMALIZEVECTOR)(float *v);
 extern NORMALIZEVECTOR NormalizeVector;

--- a/src/Glide64/ucode02.h
+++ b/src/Glide64/ucode02.h
@@ -40,7 +40,7 @@
 static void calc_point_light (VERTEX *v, float * vpos)
 {
   float light_intensity = 0.0f;
-  register float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
+  float color[3] = {rdp.light[rdp.num_lights].r, rdp.light[rdp.num_lights].g, rdp.light[rdp.num_lights].b};
   for (wxUint32 l=0; l<rdp.num_lights; l++)
   {
     if (rdp.light[l].nonblack)

--- a/src/GlideHQ/TxUtil.cpp
+++ b/src/GlideHQ/TxUtil.cpp
@@ -271,8 +271,8 @@ TxUtil::Adler32(const uint8* data, int Len, uint32 dwAdler32)
   /* zlib adler32 */
   return adler32(dwAdler32, data, Len);
 #else
-  register uint32 s1 = dwAdler32 & 0xFFFF;
-  register uint32 s2 = (dwAdler32 >> 16) & 0xFFFF;
+  uint32 s1 = dwAdler32 & 0xFFFF;
+  uint32 s2 = (dwAdler32 >> 16) & 0xFFFF;
   int k;
 
   while (Len > 0) {

--- a/src/Glitch64/OGLEStextures.cpp
+++ b/src/Glitch64/OGLEStextures.cpp
@@ -440,7 +440,7 @@ grTexDownloadMipMap( GrChipID_t tmu,
 
     // VP fixed the texture conversions to be more accurate, also swapped
     // the for i/j loops so that is is less likely to break the memory cache
-    register int n = 0, m = 0;
+    int n = 0, m = 0;
     switch(info->format)
     {
     case GR_TEXFMT_ALPHA_8:

--- a/src/Glitch64/OGLtextures.cpp
+++ b/src/Glitch64/OGLtextures.cpp
@@ -434,7 +434,7 @@ grTexDownloadMipMap( GrChipID_t tmu,
 
     // VP fixed the texture conversions to be more accurate, also swapped
     // the for i/j loops so that is is less likely to break the memory cache
-    register int n = 0, m = 0;
+    int n = 0, m = 0;
     switch(info->format)
     {
     case GR_TEXFMT_ALPHA_8:


### PR DESCRIPTION
Clang-6.0.0:

    warning: 'register' storage class specifier is deprecated and incompatible with CC++17 [-Wdeprecated-register]