### PR TITLE
Remove MAX_NUMCORE.

### DIFF
--- a/src/GlideHQ/TxFilter.cpp
+++ b/src/GlideHQ/TxFilter.cpp
@@ -290,8 +290,8 @@ TxFilter::filter(uint8 *src, int srcwidth, int srcheight, uint16 srcformat, uint
           numcore--;
         }
         if (blkrow > 0 && numcore > 1) {
-          SDL_Thread *thrd[MAX_NUMCORE];
-          FilterParams params[MAX_NUMCORE];
+          SDL_Thread *thrd[numcore];
+          FilterParams params[numcore];
           unsigned int i;
           int blkheight = blkrow << 2;
           unsigned int srcStride = (srcwidth * blkheight) << 2;

--- a/src/GlideHQ/TxQuantize.cpp
+++ b/src/GlideHQ/TxQuantize.cpp
@@ -1832,8 +1832,8 @@ TxQuantize::quantize(uint8* src, uint8* dest, int width, int height, uint16 srcf
       numcore--;
     }
     if (blkrow > 0 && numcore > 1) {
-      SDL_Thread *thrd[MAX_NUMCORE];
-      QuantizeParams params[MAX_NUMCORE];
+      SDL_Thread *thrd[numcore];
+      QuantizeParams params[numcore];
       unsigned int i;
       int blkheight = blkrow << 2;
       unsigned int srcStride = (width * blkheight) << (2 - bpp_shift);
@@ -1904,8 +1904,8 @@ TxQuantize::quantize(uint8* src, uint8* dest, int width, int height, uint16 srcf
       numcore--;
     }
     if (blkrow > 0 && numcore > 1) {
-      SDL_Thread *thrd[MAX_NUMCORE];
-      QuantizeParams params[MAX_NUMCORE];
+      SDL_Thread *thrd[numcore];
+      QuantizeParams params[numcore];
       unsigned int i;
       int blkheight = blkrow << 2;
       unsigned int srcStride = (width * blkheight) << 2;
@@ -1975,8 +1975,8 @@ TxQuantize::FXT1(uint8 *src, uint8 *dest,
       numcore--;
     }
     if (blkrow > 0 && numcore > 1) {
-      SDL_Thread     *thrd[MAX_NUMCORE];
-      CompressParams  params[MAX_NUMCORE];
+      SDL_Thread     *thrd[numcore];
+      CompressParams  params[numcore];
       unsigned int i;
       int blkheight = blkrow << 2;
       unsigned int srcStride = (srcwidth * blkheight) << 2;
@@ -2091,8 +2091,8 @@ TxQuantize::DXTn(uint8 *src, uint8 *dest,
         numcore--;
       }
       if (blkrow > 0 && numcore > 1) {
-        SDL_Thread     *thrd[MAX_NUMCORE];
-        CompressParams  params[MAX_NUMCORE];
+        SDL_Thread     *thrd[numcore];
+        CompressParams  params[numcore];
         unsigned int i;
         int blkheight = blkrow << 2;
         unsigned int srcStride = (srcwidth * blkheight) << 2;

--- a/src/GlideHQ/TxUtil.h
+++ b/src/GlideHQ/TxUtil.h
@@ -24,9 +24,6 @@
 #ifndef __TXUTIL_H__
 #define __TXUTIL_H__
 
-/* maximum number of CPU cores allowed */
-#define MAX_NUMCORE 8
-
 #include "TxInternal.h"
 #include <string>
 


### PR DESCRIPTION
This fixes a bug I hit in TxQuantize.cpp: the params array is
initialized with length MAX_NUMCORE, but accessed at positions up to
numcore-1. The numcore variable is not constrained to MAX_NUMCORE, so on
systems with cores greater than MAX_NUMCORE, there can be a segfault.

Is there any downside? I don't see one; I'm not familiar with the code,
but it looks like this may cause a negligible decrease in memory usage
on systems with less than MAX_NUMCORE (8) cores, and negligibly higher
memory usage on systems with a higher number of cores as the price of
not segfaulting.

I do not know if I have exercised all code paths in testing this change,
but the usage of MAX_NUMCORE seems the same in all cases.