### PR TITLE
fix presumed off-by-one bug in TxQuantize::quantize

### DIFF
--- a/src/GlideHQ/TxQuantize.cpp
+++ b/src/GlideHQ/TxQuantize.cpp
@@ -1838,7 +1838,7 @@ TxQuantize::quantize(uint8* src, uint8* dest, int width, int height, uint16 srcf
       int blkheight = blkrow << 2;
       unsigned int srcStride = (width * blkheight) << (2 - bpp_shift);
       unsigned int destStride = srcStride << bpp_shift;
-      for (i = 0; i < numcore - 1; i++) {
+      for (i = 0; i < numcore; i++) {
           params[i].func = quantizer;
           params[i].src = (uint32*) src;
           params[i].dest = (uint32*) dest;


### PR DESCRIPTION
The surrounding code is structured as if it expects the loop to run as
'< numcore'. Changing the loop conditional makes it consistent with
all the other 'numcore' loops in the file, and is presumably the correct
fix. Unfortunately, I do not know how to exercise this piece of code, so
the patch is given as-is.

Discussed in:
https://github.com/mupen64plus/mupen64plus-video-glide64mk2/issues/100