### PR TITLE
Fix clang errors

### DIFF
--- a/src/Glitch64/OGLEScombiner.cpp
+++ b/src/Glitch64/OGLEScombiner.cpp
@@ -226,7 +226,7 @@ void check_compile(GLuint shader)
   {
     char log[1024];
     glGetShaderInfoLog(shader,1024,NULL,log);
-    LOGINFO(log);
+    LOGINFO("%s", log);
   }
 }
 
@@ -238,7 +238,7 @@ void check_link(GLuint program)
 {
     char log[1024];
     glGetProgramInfoLog(program,1024,NULL,log);
-    LOGINFO(log);
+    LOGINFO("%s", log);
   }
 }
 

--- a/src/Glitch64/OGLESglitchmain.cpp
+++ b/src/Glitch64/OGLESglitchmain.cpp
@@ -221,7 +221,7 @@ void display_warning(const char *text, ...)
     vsprintf(buf, text, ap);
     va_end(ap);
     first_message--;
-    LOGINFO(buf);
+    LOGINFO("%s", buf);
   }
 }
 


### PR DESCRIPTION
A recent commit is causing the same compilation error with clang in several places. This is the error I'm getting:
```
error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
```
Doing what I did below seems to fix the errors.