### PR TITLE
CI/CD: Integrate scheduled builds and other...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,10 @@ on:
       - '**/*.md'
       - '.{gitattributes,gitignore,travis.yml}'
       - 'appveyor.yml,README'
+  schedule:
+    - cron: '25 14 21 * *'
   workflow_dispatch:
+
 jobs:
 
   Linux:
@@ -33,14 +36,16 @@ jobs:
             bits: 32
     name: Linux / ${{ matrix.cc }} / ${{ matrix.platform }}
     runs-on: ubuntu-22.04
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-glide64mk2') || (github.event_name != 'schedule')
     steps:
       - uses: actions/checkout@v3
       - name: Get build dependencies and arrange the environment
         run: |
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then sudo dpkg --add-architecture i386; fi
+          echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then sudo dpkg --add-architecture i386; fi
           sudo apt-get update
           sudo apt-get -y install libgl1-mesa-dev libboost-filesystem-dev libpng-dev libsdl1.2-dev libsdl2-dev zlib1g-dev
-          if [[ "${{ matrix.platform }}" == "x86" ]]; then
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then
             sudo apt-get --reinstall -y install gcc-multilib g++-multilib libc6 libc6-dev-i386 libgl1-mesa-glx:i386 libboost-filesystem1.74.0:i386 libboost-system1.74.0:i386 libpng16-16:i386 libsdl1.2debian:i386 libsdl2-2.0-0:i386 zlib1g:i386
             LINK="sudo ln -s -T"
             cd /usr/lib/i386-linux-gnu
@@ -55,27 +60,23 @@ jobs:
             if ! [[ -f _real_SDL_config.h ]]; then ${LINK} ../x86_64-linux-gnu/SDL2/_real_SDL_config.h _real_SDL_config.h; fi
           fi
           sudo ldconfig
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
-          G_REV=$(git rev-parse --short HEAD)
-          echo "G_REV=${G_REV}" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1" CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
-          if [[ "${{ matrix.cc }}" == "GCC" ]]; then
-            CC="gcc"
-            CXX="g++"
-          else
+          CC="gcc"
+          CXX="g++"
+          if [[ "${{ matrix.cc }}" != "GCC" ]]; then
             CC="clang"
             CXX="clang++"
           fi
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export PIC="1"; fi
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
           MSG="1.2"
-          mkdir tmp
-          for SDL in sdl sdl2
-          do
+          mkdir pkg
+          for SDL in sdl sdl2; do
             echo ""
             echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL${MSG} ::"
             echo ""
@@ -83,22 +84,20 @@ jobs:
             echo ""
             make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" SDL_CONFIG="${SDL}-config" -C projects/unix all -j4
             echo ""
-            make -C projects/unix install DESTDIR="${ORIG}/tmp"
+            make -C projects/unix install DESTDIR="${ORIG}/pkg/"
             echo ""
-            cd tmp/usr/local/lib/mupen64plus
-            ls -gG *.so
-            ldd mupen64plus-video-glide64mk2.so
+            ls -gG pkg/usr/local/lib/mupen64plus/*.so
+            echo ""
+            ldd pkg/usr/local/lib/mupen64plus/mupen64plus-video-glide64mk2.so
             MSG="2"
-            cd "${ORIG}"
           done
-          mkdir pkg
-          if [[ "${CC}" == "gcc" ]]; then tar cvzf pkg/mupen64plus-video-glide64mk2-${{ matrix.platform }}-g${G_REV}.tar.gz -C tmp/ "usr"; fi
+          tar cvzf pkg/mupen64plus-video-glide64mk2-linux-${{ matrix.platform }}-g${{ env.G_REV }}.tar.gz -C pkg/ "usr"
       - name: Upload artifact
+        if: matrix.cc == 'GCC'
         uses: actions/upload-artifact@v3
         with:
-          name: mupen64plus-video-glide64mk2-${{ matrix.platform }}-g${{ env.G_REV }}
-          path: pkg/*
-          if-no-files-found: ignore
+          name: mupen64plus-video-glide64mk2-linux-${{ matrix.platform }}-g${{ env.G_REV }}
+          path: pkg/*.tar.gz
 
   MSYS2:
     strategy:
@@ -114,7 +113,8 @@ jobs:
             cross: i686
             bits: 32
     name: Windows / MSYS2 ${{ matrix.cc }} / ${{ matrix.platform }}
-    runs-on: windows-2019
+    runs-on: windows-2022
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-glide64mk2') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: msys2 {0}
@@ -135,17 +135,18 @@ jobs:
             mingw-w64-${{ matrix.cross }}-libpng
             mingw-w64-${{ matrix.cross }}-SDL2
             mingw-w64-${{ matrix.cross }}-zlib
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          if [[ ${{ matrix.bits }} -eq 32 ]]; then export OPTFLAGS="-O2 -flto -mtune=pentium4"; else export OPTFLAGS="-O2 -flto -mtune=core2"; fi
           echo "G_REV=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
+          if [[ ${{ matrix.bits }} -eq 32 ]]; then CPU_TUNE="-msse2 -mtune=pentium4"; else CPU_TUNE="-mtune=core2"; fi
+          export OPTFLAGS="-O2 -flto ${CPU_TUNE}"
           ORIG="$(pwd)"
           CC="gcc"
           CXX="g++"
           ${CC} --version
           echo ""
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ../mupen64plus-core
-          mkdir tmp
+          mkdir pkg
           echo ""
           echo ":: ${{ matrix.cc }} ${{ matrix.platform }} / SDL2 ::"
           echo ""
@@ -153,32 +154,17 @@ jobs:
           echo ""
           make CC="${CC}" CXX="${CXX}" BITS="${{ matrix.bits }}" -C projects/unix all -j4
           echo ""
-          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/tmp"
+          make -C projects/unix install PLUGINDIR="" SHAREDIR="" BINDIR="" MANDIR="" LIBDIR="" APPSDIR="" ICONSDIR="icons" INCDIR="api" LDCONFIG="true" DESTDIR="${ORIG}/pkg/"
           echo ""
-          ls -gG tmp/*.dll
-          ldd tmp/mupen64plus-video-glide64mk2.dll
-      - name: Copy binaries, dependencies, etc...
+          ls -gG pkg/*.dll
+          echo ""
+          ldd pkg/mupen64plus-video-glide64mk2.dll
+      - name: Backup dependencies, etc...
         run: |
-          mkdir pkg
           if [[ ${{ matrix.bits }} -eq 32 ]]; then LIBGCC="libgcc_s_dw2-1"; else LIBGCC="libgcc_s_seh-1"; fi
-          for LIB in glew32 libboost_filesystem-mt ${LIBGCC} libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1
-          do
+          for LIB in glew32 libboost_filesystem-mt ${LIBGCC} libpng16-16 libstdc++-6 libwinpthread-1 SDL2 zlib1; do
             echo ":: Copying ${LIB}.dll"
             cp "/mingw${{ matrix.bits }}/bin/${LIB}.dll" pkg/
-          done
-          if [ -d data ]; then
-            cd data
-            for DAT in *
-            do
-              echo ":: Copying ${DAT}"
-              cp -r "${DAT}" ../pkg/
-            done
-          fi
-          cd ../tmp
-          for BIN in *.dll
-          do
-            echo ":: Copying ${BIN}"
-            cp "${BIN}" ../pkg/
           done
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -197,20 +183,18 @@ jobs:
           - toolset: v141_xp
             platform: x86
             vs: 2019
-    name: Windows / MSVC ${{ matrix.toolset }} / ${{ matrix.platform }}
+    name: Windows / MSVC with ${{ matrix.toolset }} / ${{ matrix.platform }}
     runs-on: windows-${{ matrix.vs }}
+    if: (github.event_name == 'schedule' && github.repository == 'mupen64plus/mupen64plus-video-glide64mk2') || (github.event_name != 'schedule')
     defaults:
       run:
         shell: cmd
     steps:
       - uses: actions/checkout@v3
       - uses: microsoft/setup-msbuild@v1
-    #  with:
-    #    vs-version: 16.11
-      - name: Build and related stuff
+      - name: Build and related stuff, backup binaries
         run: |
-          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do set "G_REV=%%R"
-          echo G_REV=%G_REV%>> "%GITHUB_ENV%"
+          for /f "tokens=1" %%R in ('git rev-parse --short HEAD') do echo G_REV=%%R>> "%GITHUB_ENV%"
           set "ARCH=${{ matrix.platform }}"
           if [%ARCH%] == [x86] set "ARCH=Win32"
           echo.
@@ -218,19 +202,16 @@ jobs:
           echo.
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-core.git ..\mupen64plus-core
           git clone --depth 1 https://github.com/mupen64plus/mupen64plus-win32-deps.git ..\mupen64plus-win32-deps
+          md pkg
           echo.
           msbuild projects\msvc\mupen64plus-video-glide64mk2.vcxproj /p:Configuration=Release;Platform=%ARCH%;PlatformToolset=${{ matrix.toolset }}
           echo.
-          md backup
-          copy projects\msvc\%ARCH%\Release\mupen64plus-video-glide64mk2.dll backup\
-          dir backup\*.dll
-      - name: Copy binaries, dependencies, etc...
+          copy "projects\msvc\%ARCH%\Release\mupen64plus-video-glide64mk2.dll" pkg\
+          dir pkg\*.dll
+      - name: Backup dependencies, etc...
         run: |
-          md pkg
-          cd pkg
-          xcopy "..\backup" .
-          xcopy "..\data" .
-          copy "..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\${{ matrix.platform }}\*.dll" .
+          xcopy data pkg
+          copy "..\mupen64plus-win32-deps\SDL2-2.26.3\lib\${{ matrix.platform }}\*.dll" pkg\
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -239,8 +220,8 @@ jobs:
 
   Nightly-build:
     runs-on: ubuntu-latest
+    if: github.ref_name == 'master'
     needs: [Linux, MSYS2, MSVC]
-    if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v3
       - name: Download artifacts
@@ -255,8 +236,7 @@ jobs:
         run: |
           mkdir pkg
           cd binaries
-          for BIN in *
-          do
+          for BIN in *; do
             cd "${BIN}"
             if [[ "${BIN:29:4}" == "msys" ]]; then
               echo ":: Creating ${BIN}.zip"
@@ -272,10 +252,9 @@ jobs:
           done
           cd ../pkg
           echo ""
-          for BIN in *
-          do
+          for BIN in *; do
             ls -gG ${BIN}
-            tigerdeep -l ${BIN} >> ../${BIN:0:28}.tiger.txt
+            tigerdeep -lz ${BIN} >> ../${BIN:0:28}.tiger.txt
             sha256sum ${BIN} >> ../${BIN:0:28}.sha256.txt
             sha512sum ${BIN} >> ../${BIN:0:28}.sha512.txt
           done

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,8 @@ version: 1.0.{build}
 
 image: Visual Studio 2022
 
+skip_tags: true
+
 skip_commits:
   files:
     - '**/*.md'
@@ -11,10 +13,6 @@ skip_commits:
     - .gitignore
     - .travis.yml
     - README
-
-branches:
-  except:
-    - nightly-build
 
 configuration:
   - Release

--- a/projects/msvc/mupen64plus-video-glide64mk2.vcxproj
+++ b/projects/msvc/mupen64plus-video-glide64mk2.vcxproj
@@ -75,7 +75,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.80.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.81.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_VARIADIC_MAX=10;_CRT_SECURE_NO_WARNINGS;__MSC__;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -83,7 +83,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;SDL2.lib;libpng16.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.80.0\lib32-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.81.0\lib32-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
@@ -91,7 +91,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.80.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.81.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;_VARIADIC_MAX=10;_CRT_SECURE_NO_WARNINGS;__MSC__;WIN32;NO_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -99,14 +99,14 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;SDL2.lib;libpng16.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.80.0\lib64-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.81.0\lib64-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.80.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.81.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_VARIADIC_MAX=10;_CRT_SECURE_NO_WARNINGS;__MSC__;WIN32;__VISUALC__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -116,7 +116,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;SDL2.lib;libpng16.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.80.0\lib32-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x86;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x86;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.81.0\lib32-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x86;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x86;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <SubSystem>Windows</SubSystem>
@@ -124,7 +124,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.80.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src\Glide64;..\..\src\Glide64\inc;..\..\src\GlideHQ;..\..\src\GlideHQ\tc-1.1+;..\..\src\Glitch64;..\..\src\Glitch64\inc;..\..\..\mupen64plus-core\src\api;..\..\..\mupen64plus-win32-deps\boost-1.81.0\;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\include;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\include;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\include;..\..\..\mupen64plus-win32-deps\opengl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_VARIADIC_MAX=10;_CRT_SECURE_NO_WARNINGS;__MSC__;WIN32;__VISUALC__;NO_ASM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -134,7 +134,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;SDL2.lib;libpng16.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.80.0\lib64-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.38\lib\x64;..\..\..\mupen64plus-win32-deps\zlib-1.2.12\lib\x64;..\..\..\mupen64plus-win32-deps\SDL2-2.24.0\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\mupen64plus-win32-deps\boost-1.81.0\lib64-msvc;..\..\..\mupen64plus-win32-deps\libpng-1.6.39\lib\x64;..\..\..\mupen64plus-win32-deps\zlib-1.2.13\lib\x64;..\..\..\mupen64plus-win32-deps\SDL2-2.26.3\lib\x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Depends on: mupen64plus/mupen64plus-win32-deps#13

Relevant changes:

- Schedule builds at least once a month (upstream only)
- Update some GitHub Actions values
- Bash code simplification and corrections
- Optimize x86 builds with SSE2 on Linux and MSYS2 (sometimes not effective)
- Tag to Linux binaries
- Add file size to tiger hashfile
- AppVeyor: Avoid duplicated jobs as a result of the `nightly-build` tag update